### PR TITLE
Allow to specify schema id when producing messages

### DIFF
--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -61,6 +61,14 @@ Producer.prototype.getProducer = Promise.method(function (opts, topicOptions) {
     .return(producer);
 });
 
+function prepareSubject(isKey, subject, topicName, data) {
+  if (isKey) {
+    return this.sr.keySubjectStrategy.prepareSubjectName(topicName, data, isKey);
+  } else {
+    return this.sr.valueSubjectStrategy.prepareSubjectName(topicName, data, isKey);
+  }
+}
+
 /**
  * Avro serialization helper.
  *
@@ -73,11 +81,10 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
   let schema = null;
   let subject = null;
 
-  if (isKey) {
-    subject = this.sr.keySubjectStrategy.prepareSubjectName(topicName, data, isKey);
-    schema = this.sr.schemas[subject];
+  if (data.__id != null) {
+    schema = this.sr.schemaIds[data.__id];
   } else {
-    subject = this.sr.valueSubjectStrategy.prepareSubjectName(topicName, data, isKey);
+    subject = prepareSubject.call(this, isKey, subject, topicName, data);
     schema = this.sr.schemas[subject];
   }
 
@@ -94,7 +101,9 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
     }
 
     if (typeof data === 'object') {
-      delete data.__schemaName; // Making sure __schemaName is not serialized in case avro schema is missing and json is used as a fallback.
+      // Making sure __schemaName and __id is not serialized in case avro schema is missing and json is used as a fallback.
+      delete data.__schemaName;
+      delete data.__id;
       return new Buffer(JSON.stringify(data));
     } else {
       return new Buffer(data);

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -82,7 +82,7 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
   let subject = null;
 
   if (data.__id != null) {
-    schema = this.sr.schemaIds[data.__id];
+    schema = this.sr.schemaTypeById[`schema-${data.__id}`];
   } else {
     subject = prepareSubject.call(this, isKey, subject, topicName, data);
     schema = this.sr.schemas[subject];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-avro",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -336,9 +336,9 @@
       "dev": true
     },
     "avsc": {
-      "version": "5.4.16",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.4.16.tgz",
-      "integrity": "sha512-Z85B8ZaEU2PWNPRJYuMSp5Hg7Nw3KPKW47lW/Kus7AcwV7fr6uJG3UckagqIPLydIeO/Cm+yjnJG7g0tliICOg=="
+      "version": "5.4.18",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.4.18.tgz",
+      "integrity": "sha512-rQwa/WrpfNm1jEzmRe78EuKvvI9uikZeZL68HqTbbPFTFgZPxExhJESHyqgwlVvWCKlYTwBezR38G1Tjkn+2Zg=="
     },
     "axios": {
       "version": "0.15.3",
@@ -1895,8 +1895,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coverage": "nyc npm run test"
   },
   "dependencies": {
-    "avsc": "^5.4.16",
+    "avsc": "^5.4.18",
     "axios": "^0.15.3",
     "bluebird": "^3.4.6",
     "bunyan": "^1.8.5",


### PR DESCRIPTION
Allow to specify schema id when producing to kafka. Otherwise kafka-avro will use the latest version