### PR TITLE
Fixing avsc failling to parse schemas with the same name

### DIFF
--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -7,6 +7,7 @@ const Promise = require('bluebird');
 const cip = require('cip');
 const axios = require('axios');
 const avro = require('avsc');
+const _ = require('lodash');
 let instance = axios;
 
 const rootLog = require('./log.lib');
@@ -118,12 +119,24 @@ const SchemaRegistry = module.exports = cip.extend(function (opts) {
 });
 
 /**
+ * Deep coping avsc parse options. Avsc will add registry to those options and if we try to parse schema with the same name it will fail
+ * e.g. with fetch all versions enabled, trying to avsc.parse an evolved version of the same schema will trow an exception that there is a duplicate schema in the registry.
+ *
+ * @param parseOptions
+ * @returns {Object}
+ */
+function deepCopyAvscParseOptionsToAvoidDuplicateSchemaException(parseOptions) {
+  return _.extend({}, parseOptions);
+}
+
+/**
  * Get the avro RecordType from a schema response.
  *
  * @return {RecordType} An avro RecordType representing the parsed avro schema.
  */
 function typeFromSchemaResponse(schema, parseOptions) {
-  const schemaType = avro.parse(schema, parseOptions);
+  // D
+  const schemaType = avro.parse(schema, deepCopyAvscParseOptionsToAvoidDuplicateSchemaException(parseOptions));
 
   //check if the schema has been previously parsed and added to the registry
   if (typeof parseOptions.registry === 'object' && typeof parseOptions.registry[schemaType.name] !== 'undefined') {

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -135,15 +135,7 @@ function deepCopyAvscParseOptionsToAvoidDuplicateSchemaException(parseOptions) {
  * @return {RecordType} An avro RecordType representing the parsed avro schema.
  */
 function typeFromSchemaResponse(schema, parseOptions) {
-  // D
-  const schemaType = avro.parse(schema, deepCopyAvscParseOptionsToAvoidDuplicateSchemaException(parseOptions));
-
-  //check if the schema has been previously parsed and added to the registry
-  if (typeof parseOptions.registry === 'object' && typeof parseOptions.registry[schemaType.name] !== 'undefined') {
-    return parseOptions.registry[schemaType.name];
-  }
-
-  return avro.parse(schema, parseOptions);
+  return avro.parse(schema, deepCopyAvscParseOptionsToAvoidDuplicateSchemaException(parseOptions));
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-avro",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Deep coping avsc parse options. Avsc will add registry to those options and if we try to parse schema with the same name it will fail
e.g. with fetch all versions enabled, trying to avsc.parse an evolved version of the same schema will throw an exception that there is a duplicate schema in the registry.